### PR TITLE
Unlimited recursion bug when getting Sink log- and ignoreParsingErrors config options

### DIFF
--- a/src/main/java/com/humio/connect/hec/HECSinkConnectorConfig.java
+++ b/src/main/java/com/humio/connect/hec/HECSinkConnectorConfig.java
@@ -109,8 +109,8 @@ public class HECSinkConnectorConfig extends AbstractConfig {
 
     public String getPartitionField() { return this.getString(PARTITION_FIELD); }
 
-    public boolean ignoreParsingErrors() { return this.ignoreParsingErrors(); }
+    public boolean ignoreParsingErrors() { return this.getBoolean(IGNORE_PARSING_ERRORS); }
 
-    public boolean logParsingErrors() { return this.logParsingErrors(); }
+    public boolean logParsingErrors() { return this.getBoolean(LOG_PARSING_ERRORS); }
 
 }

--- a/src/test/java/com/humio/connect/hec/HECSinkConnectorConfigTest.java
+++ b/src/test/java/com/humio/connect/hec/HECSinkConnectorConfigTest.java
@@ -85,4 +85,16 @@ class HECSinkConnectorConfigTest {
         HECSinkConnectorConfig config = new HECSinkConnectorConfig(props);
         Assert.assertEquals(config.getString(HECSinkConnectorConfig.PARTITION_FIELD), null);
     }
+
+    @Test
+    public void testIgnoreParsingErrorsOption() {
+        HECSinkConnectorConfig config = new HECSinkConnectorConfig(props);
+        Assert.assertEquals(false, config.ignoreParsingErrors());
+    }
+
+    @Test
+    public void testLogParsingErrorsOption() {
+        HECSinkConnectorConfig config = new HECSinkConnectorConfig(props);
+        Assert.assertEquals(true, config.logParsingErrors());
+    }
 }


### PR DESCRIPTION
This PR adresses the bug reported in [issue 1](https://github.com/humio/kafka-connect-hec-sink/issues/1):

> When the Humio HEC sink encounters an error, during processing of a record, the configuration regarding whether to ignore failures and log failures are read. 
> The current implementation has a bug, where the getter methods for these configuration properties call them selves rather than read the corresponding configuration property.

The fix simply reads the proper configuration properties, as stated in the documentation. There is also unit test coverage for the fix.
