### PR TITLE
Optional, primitive fields are not supported when converting from Avro

### DIFF
--- a/src/main/java/com/humio/connect/hec/converter/AvroConverter.java
+++ b/src/main/java/com/humio/connect/hec/converter/AvroConverter.java
@@ -7,6 +7,7 @@
 package com.humio.connect.hec.converter;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.humio.connect.hec.Record;
 import org.apache.kafka.connect.data.Field;
@@ -73,7 +74,9 @@ public class AvroConverter implements RecordConverter {
     private void handlePrimitiveField(JsonObject obj, Struct struct, Field field) {
         final String fieldName = field.name();
         final Object val = struct.get(field);
-        if (val instanceof Number) {
+        if (val == null) {
+            obj.add(fieldName, JsonNull.INSTANCE);
+        } else if (val instanceof Number) {
             obj.addProperty(fieldName, (Number) val);
         } else if (val instanceof String) {
             obj.addProperty(fieldName, (String) val);

--- a/src/test/java/com/humio/connect/hec/converter/AvroConverterTest.java
+++ b/src/test/java/com/humio/connect/hec/converter/AvroConverterTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import static com.humio.connect.hec.converter.ConverterTestUtils.makeSinkRecord;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AvroConverterTest {
     private AvroConverter converter = new AvroConverter();
@@ -33,6 +34,7 @@ class AvroConverterTest {
                 .field("month", Schema.STRING_SCHEMA)
                 .field("day", Schema.INT8_SCHEMA)
                 .field("year", Schema.INT16_SCHEMA)
+                .field("nullable_field", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
 
         Struct struct = new Struct(valueSchema)
@@ -47,7 +49,8 @@ class AvroConverterTest {
         assertAll(
                 () -> assertEquals("january", obj.get("month").getAsString()),
                 () -> assertEquals(8, obj.get("day").getAsByte()),
-                () -> assertEquals(1977, obj.get("year").getAsShort())
+                () -> assertEquals(1977, obj.get("year").getAsShort()),
+                () -> assertTrue(obj.get("nullable_field").isJsonNull())
         );
     }
 


### PR DESCRIPTION
This PR adresses the bug reported in [issue 3](https://github.com/humio/kafka-connect-hec-sink/issues/3):

> Given a Avro object that contains an optional, primitive field, the AvroConverter fails with an exception:
>
> `org.apache.kafka.connect.errors.DataException: unexpected / unsupported schema type STRING - primitive field not one of (Number, String, Boolean)`

The fix was to add a null check and add a `JsonNull` property to the `JsonObject`. I added to the unit test covering basic types, such that there is coverage for optional, primitive fields as well.