### PR TITLE
Update log4j to latest version to fix CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.16.0</version>
+                <version>2.17.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
# Fix logshell vulnerability

Link To Issue Being Solved: No issue in tracker

**What Changes Have Been Made?**

This fixes CVE-2021-45105. Its a simple dependency bump.

**Why Have the Changes Been Made?**

To increase the security of the HEC sink.

**How Do These Changes Impact the User?**

None as far as I'm aware.